### PR TITLE
fix: update CORS allowed origins handling

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -49,9 +49,13 @@ func main() {
 	app.Use(etag.New())
 
 	urls := os.Getenv("URL")
+	allowedOrigins := "http://localhost:243"
+	if urls != "" {
+		allowedOrigins += "," + urls
+	}
 
 	app.Use(cors.New(cors.Config{
-		AllowOrigins:     urls + ", http://localhost:243",
+		AllowOrigins:     allowedOrigins,
 		AllowMethods:     "GET,POST,PUT,DELETE,OPTIONS",
 		AllowHeaders:     "Origin,Content-Type,Accept,X-CSRF-Token,Authorization",
 		ExposeHeaders:    "Content-Length",


### PR DESCRIPTION
Current URL append method was causing error, so updated the CORS configuration to dynamically append the URLs specified in the URL environment variable.
![Screenshot 2025-02-15 093057](https://github.com/user-attachments/assets/f7d49ac0-605a-406a-ad3d-4cb695be6458)
![image](https://github.com/user-attachments/assets/c7dd2ee7-2f2d-4ece-8ad0-2f39874741a0)

